### PR TITLE
Add missing express

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/package.json
+++ b/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "angular-e2e-test-lab",
+  "version": "1.0.0",
+  "description": "## Objectives",
+  "main": "conf.js",
+  "dependencies": {},
+  "devDependencies": {
+    "express": "4.13.4"
+  },
+  "scripts": {
+    "test": "learn"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/learn-co-curriculum/angular-e2e-test-lab.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/learn-co-curriculum/angular-e2e-test-lab/issues"
+  },
+  "homepage": "https://github.com/learn-co-curriculum/angular-e2e-test-lab#readme"
+}

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "angular-e2e-test-lab",
   "version": "1.0.0",
   "description": "## Objectives",
-  "main": "conf.js",
+  "main": "spec/server.js",
   "dependencies": {},
   "devDependencies": {
     "express": "4.13.4"


### PR DESCRIPTION
`server.js` errors out when you try to run the spec because `express` is not installed. This adds a `package.json` for specifying the dependency.
